### PR TITLE
Meagre progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/__pycache__
+scratch/

--- a/poetry.lock
+++ b/poetry.lock
@@ -410,6 +410,20 @@ toolz = ">=0.9.0"
 typing-extensions = ">=4.2.0"
 
 [[package]]
+name = "click"
+version = "8.1.7"
+description = "Composable command line interface toolkit"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
+    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -1385,6 +1399,20 @@ files = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.8.0"
+description = "Node.js virtual environment builder"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+files = [
+    {file = "nodeenv-1.8.0-py2.py3-none-any.whl", hash = "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"},
+    {file = "nodeenv-1.8.0.tar.gz", hash = "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2"},
+]
+
+[package.dependencies]
+setuptools = "*"
+
+[[package]]
 name = "notebook"
 version = "7.0.6"
 description = "Jupyter Notebook - A web-based notebook environment for interactive computing"
@@ -1826,6 +1854,24 @@ files = [
 [package.extras]
 plugins = ["importlib-metadata"]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pyright"
+version = "1.1.342"
+description = "Command line wrapper for pyright"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyright-1.1.342-py3-none-any.whl", hash = "sha256:9a7b95b3a2a90ef7b4297221173956f7f2db2a6cf4f0c7493f2a2349d38305fc"},
+    {file = "pyright-1.1.342.tar.gz", hash = "sha256:c8e9785b9080c1aaf2a2efad706249ec65e15abd5f542ee455956acfd404d273"},
+]
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+
+[package.extras]
+all = ["twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
 
 [[package]]
 name = "python-dateutil"
@@ -2600,4 +2646,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "4f7a06e1174040cf36cbd020a20bed23fea80cf50b7bed5b91ce5ad86bd953d8"
+content-hash = "9105db365ebd96b341e5e09a167edfe906d09507df130f30e40feb5a7776bc9d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ optional = true
 jupyter = "^1.0.0"
 ipython = "^8.18.1"
 mypy = "^1.7.1"
+pyright = "^1.1.342"
 
 [tool.poetry.group.experimental]
 optional = true
@@ -30,6 +31,7 @@ jax = {version = "0.4.21", extras = ["cuda12_pip"], source = "google-jax"}
 jaxtyping = "^0.2.24"
 equinox = "^0.11.2"
 optax = "^0.1.7"
+click = "^8.1.7"
 
 [[tool.poetry.source]]
 name = "google-jaxlib"

--- a/scripts/experimental/experiment-1.py
+++ b/scripts/experimental/experiment-1.py
@@ -1,0 +1,359 @@
+"""Smoke test - teach a simple MPL the rules of Plantation."""
+
+import json
+from pathlib import Path
+import random
+import sys
+from typing import BinaryIO, Self
+
+import click
+import equinox as eqx
+import jax
+import jax.lax as lax
+import jax.numpy as jnp
+import jax.random as jr
+from jaxtyping import Array, Float, PRNGKeyArray, PyTree, Scalar, UInt
+import optax
+from optax import GradientTransformation, OptState
+
+sys.path.insert(0, str(Path(__file__).parent / "lib"))
+from v1.agxnt import (
+    AbstractAgent,
+    ExoState,
+    Simulator,
+    StateEnvelope,
+    Trainer,
+    TrainStepFn,
+)
+from v1.game import (  # type: ignore
+    allowed_actions,
+    BoardUInt,
+    BOARD_HEIGHT,
+    BOARD_WIDTH,
+    NUM_ACTIONS,
+)
+
+
+type ActionPMF = Float[Array, "height width actions"]
+"""The action probability mass function by which an agent expresses its will"""
+
+type ActionPMFs = Float[Array, "sim_steps height width actions"]
+
+type BoardUIntSeq = UInt[Array, "sim_steps height width"]
+
+type BoardUIntBatch = UInt[Array, "batch_size height width"]
+
+type BoardUIntSeqBatch = UInt[Array, "batch_size sim_steps height width"]
+
+
+class LearningAgent[State](AbstractAgent[State, ActionPMF, BoardUInt]):
+    trainable_map: PyTree # TODO How to say "callable Module"?
+    hyperparams: dict = eqx.field(static=True)
+
+    @classmethod
+    def make_dev_agent(
+        cls,
+        *,
+        board_height: int,
+        board_width: int,
+        num_actions: int,
+        mlp_width: int,
+        mlp_depth: int,
+        key: PRNGKeyArray,
+    ) -> Self:
+        trainable_map = eqx.nn.Sequential([
+            eqx.nn.Lambda(jnp.ravel),
+            eqx.nn.MLP(
+                in_size=board_height * board_width,
+                out_size=board_height * board_width * num_actions,
+                width_size=mlp_width,
+                depth=mlp_depth,
+                key=key,
+            ),
+            eqx.nn.Lambda(jax.nn.softmax),  # TODO Inspect
+            eqx.nn.Lambda(
+                lambda x: x.reshape(board_height, board_width, num_actions)
+            ),
+        ])
+
+        return cls(
+            trainable_map,
+            hyperparams = {
+                "board_height": board_height,
+                "board_width": board_width,
+                "num_actions": num_actions,
+                "mlp_width": mlp_width,
+                "mlp_depth": mlp_depth,
+            }
+        )
+    
+    @classmethod
+    def load(cls, source: BinaryIO) -> Self:
+        params = json.loads(source.readline().decode())
+        agent = cls.make_dev_agent(**params, key=jr.PRNGKey(0))
+
+        return eqx.tree_deserialise_leaves(source, agent)
+
+    def save(self, target: BinaryIO):
+        structure = (json.dumps(self.hyperparams) + "\n").encode()
+        target.write(structure)
+        eqx.tree_serialise_leaves(target, self)
+
+    def react(
+        self,
+        state: State,
+        exo_state: BoardUInt,
+    ) -> ActionPMF:
+        return self.trainable_map(exo_state)
+
+
+def dynamics(
+    state_envelope: StateEnvelope[None, ActionPMF],
+    exo_state: BoardUInt,
+) -> tuple[StateEnvelope[None, ActionPMF], ActionPMF]:
+    agent: LearningAgent[None] = eqx.combine(
+        state_envelope.agent_dynamic_tree,
+        state_envelope.agent_static_tree,
+    )
+    new_state = state_envelope.state  # no-op
+    action = agent.react(new_state, exo_state)
+
+    return StateEnvelope[None, ActionPMF](
+        *eqx.partition(agent, filter_spec=eqx.is_array), new_state, action
+    ), state_envelope.action
+
+
+def score_action_legal_uniform(
+    action: ActionPMF,
+    board: BoardUInt,
+) -> Scalar:
+    """Evaluates an action pmf for compliance with the rules of the game.
+
+    Penalises
+    - probabiliy mass on illegal moves
+    - non-uniform density on legal moves
+
+    TODO Devise a score less sensitive to then number of occupied cells.
+    """
+    legal_actions = allowed_actions(board)
+    good_pm = jnp.where(legal_actions, action, 0.0)
+    evil_pm = jnp.where(~legal_actions, action, 0.0)
+
+    n = jnp.count_nonzero(legal_actions).astype(float)
+    good_absdev = jnp.where(
+        legal_actions,
+        lax.abs(action - good_pm.sum() / n),
+        0.0,
+    )
+
+    return 1.0 - evil_pm.sum() - good_absdev.mean()
+
+
+def make_train_step(
+    agent: LearningAgent[None],
+    sim_fn: Simulator[
+        None, ActionPMF, BoardUInt, BoardUIntSeq, ActionPMF, ActionPMFs
+    ],
+    optimiser: GradientTransformation,
+    sim_steps: int,
+    batch_size: int,
+    lam: float,
+) -> tuple[
+        TrainStepFn[OptState, None, ActionPMF, BoardUInt],
+        OptState
+    ]:
+    @eqx.filter_grad
+    def compute_loss(
+        agent: LearningAgent[None],
+        exo_state: ExoState[BoardUIntBatch, BoardUIntSeqBatch],
+    ) -> Scalar:
+        actions = eqx.filter_vmap(
+            sim_fn, in_axes=(None, None, 0)
+        )(agent, None, exo_state)
+
+        boards = jnp.roll(exo_state.sequence, shift=1, axis=1)
+        boards = boards.at[:, 0].set(exo_state.initial)
+
+        # Merge batch and sequence dims
+        actions = actions.reshape(-1, *actions.shape[-3:])
+        boards = boards.reshape(-1, *boards.shape[-2:])
+
+        scores = jax.vmap(score_action_legal_uniform)(actions, boards)
+
+        return -scores.mean()
+
+    @eqx.filter_jit
+    def train_step(
+        agent: LearningAgent[None],
+        train_state: OptState,
+        rng_key: PRNGKeyArray,
+    ) -> tuple[LearningAgent[None], OptState]:
+        k1, k2 = jr.split(rng_key)
+
+        exo_state = ExoState[BoardUIntBatch, BoardUIntSeqBatch](
+            initial=jr.poisson(
+                k1,
+                lam=lam,
+                shape=(batch_size, BOARD_HEIGHT, BOARD_WIDTH),
+            ),
+            sequence=jr.poisson(
+                k2,
+                lam=lam,
+                shape=(batch_size, sim_steps, BOARD_HEIGHT, BOARD_WIDTH),
+            ),
+        )
+
+        grads = compute_loss(agent, exo_state)
+
+        updates, train_state = optimiser.update(
+            grads, train_state, params=agent  # type: ignore  # FIXME
+        )
+        agent = eqx.apply_updates(agent, updates)
+
+        return agent, train_state
+
+    opt_state = optimiser.init(eqx.filter(agent, eqx.is_array))
+
+    return train_step, opt_state  # type: ignore  # FIXME
+
+
+def test(
+    agent: LearningAgent[None],
+    lam: float,
+    rng_key: PRNGKeyArray,
+    batch_size: int = 10000,
+):
+    boards = jr.poisson(
+        rng_key, lam=lam, shape=(batch_size, BOARD_HEIGHT, BOARD_WIDTH)
+    )
+
+    actions = eqx.filter_vmap(
+        agent.react, in_axes=(None, 0),
+    )(None, boards)
+
+    scores = jax.vmap(score_action_legal_uniform)(actions, boards)
+
+    return scores.mean()
+
+
+TRAIN_STEPS = 100
+LEARNING_RATE = 1e-3
+SIM_STEPS = 1
+BATCH_SIZE = 1024
+LAMBDA = 0.25
+MLP_WIDTH = 128
+MLP_DEPTH = 1
+
+
+@click.command
+@click.option(
+    "--load",
+    type=click.File("rb"),
+)
+@click.option(
+    "--save",
+    type=click.File("wb"),
+)
+@click.option(
+    "--train-steps",
+    type=click.IntRange(min=0),
+    default=TRAIN_STEPS,
+)
+@click.option(
+    "--learning-rate",
+    type=click.FloatRange(min=0.0, min_open=True),
+    default=LEARNING_RATE,
+)
+@click.option(
+    "--sim-steps",
+    type=click.IntRange(min=0),  # FIXME Fails at bound
+    default=SIM_STEPS,
+)
+@click.option(
+    "--batch-size",
+    type=click.IntRange(min=0),  # TODO Check behaviour at bound
+    default=BATCH_SIZE,
+)
+@click.option(
+    "--lambda", "lambda_",
+    type=click.FloatRange(min=0.0, min_open=True),
+    default=LAMBDA,
+)
+@click.option(
+    "--mlp-width",
+    type=click.IntRange(min=0, min_open=True),
+    default=MLP_WIDTH,
+)
+@click.option(
+    "--mlp-depth",
+    type=click.IntRange(min=0, min_open=True),
+    default=MLP_DEPTH,
+)
+@click.option(
+    "--rng-seed",
+    type=click.IntRange(min=0),
+    default=lambda: random.SystemRandom().randint(0, 2**32 - 1),
+)
+def train_cmd(
+    *,
+    load,
+    save,
+    train_steps,
+    learning_rate,
+    sim_steps,
+    batch_size,
+    lambda_,
+    mlp_width,
+    mlp_depth,
+    rng_seed,
+):
+    key = jr.PRNGKey(rng_seed)
+
+    if load is None:
+        hyperparams = {
+            "board_height": BOARD_HEIGHT,
+            "board_width": BOARD_WIDTH,
+            "num_actions": NUM_ACTIONS,
+            "mlp_width": mlp_width,
+            "mlp_depth": mlp_depth,
+        }
+        key, subkey = jr.split(key)
+        agent = LearningAgent[None].make_dev_agent(**hyperparams, key=subkey)
+    else:
+        agent = LearningAgent[None].load(load)
+
+    key, subkey = jr.split(key)
+    metric = test(agent, lambda_, subkey)
+    print(f"{'Before training:':16}", f"{metric:4.6f}")
+
+    simulate = Simulator[
+        None, ActionPMF, BoardUInt, BoardUIntSeq, ActionPMF, ActionPMFs
+    ](dynamics)
+
+    optimiser = optax.adamw(learning_rate)
+    train_step, opt_state = make_train_step(
+        agent,
+        simulate,
+        optimiser,
+        sim_steps,
+        batch_size,
+        lam=lambda_,
+    )
+
+    train = Trainer[
+        PyTree, None, ActionPMF, BoardUInt,
+    ](train_step)
+
+    key, subkey = jr.split(key)
+    agent, opt_state = train(agent, opt_state, train_steps, subkey)
+
+    if save is not None:
+        agent.save(save)  # type: ignore  # TODO Bad design by me anyway
+
+    key, subkey = jr.split(key)
+    metric = test(agent, lambda_, subkey)  # type: ignore  # TODO
+    print(f"{'After training:':16}", f"{metric:4.6f}")
+
+
+if __name__ == "__main__":
+    train_cmd()

--- a/scripts/experimental/lib/v1/agxnt.py
+++ b/scripts/experimental/lib/v1/agxnt.py
@@ -1,0 +1,95 @@
+"""Scaffold for reinforcement learning with differentiable dynamics."""
+
+from abc import abstractmethod
+from typing import Callable
+
+import equinox as eqx
+from equinox import Module
+import jax.lax as lax
+import jax.random as jr
+from jaxtyping import PRNGKeyArray, PyTree
+
+
+class AbstractAgent[State, Action, ScanX](Module, strict=True):
+    @abstractmethod
+    def react(
+        self,
+        state: State,
+        exo_state: ScanX,
+    ) -> Action: ...
+
+
+type Agent[State, Action, ScanX] = AbstractAgent[State, Action, ScanX]
+
+
+class StateEnvelope[State, Action](Module, strict=True):
+    agent_dynamic_tree: PyTree
+    agent_static_tree: PyTree = eqx.field(static=True)
+    state: State
+    action: Action
+
+
+class ExoState[ScanX, ScanXS](Module, strict=True):
+    initial: ScanX
+    sequence: ScanXS
+
+
+type DynamicsFn[State, Action, ScanX, ScanY] = Callable[
+    [StateEnvelope[State, Action], ScanX],
+    tuple[StateEnvelope[State, Action], ScanY],
+]
+
+
+class Simulator[
+    State, Action, ScanX, ScanXS, ScanY, ScanYS
+](Module, strict=True):
+    dynamics: DynamicsFn[State, Action, ScanX, ScanY]
+
+    def __call__(
+        self,
+        agent: Agent[State, Action, ScanX],
+        state: State,
+        exo_state: ExoState[ScanX, ScanXS],
+    ) -> ScanYS:
+        action = agent.react(state, exo_state.initial)
+        dynamic_tree, static_tree = eqx.partition(agent, eqx.is_array)
+        _, result = lax.scan(
+            self.dynamics,  # type: ignore
+            init=StateEnvelope[State, Action](
+                dynamic_tree, static_tree, state, action
+            ),
+            xs=exo_state.sequence,
+        )
+
+        return result  # type: ignore
+
+
+type TrainStepFn[TrainState, State, Action, ScanX] = Callable[
+    [Agent[State, Action, ScanX], TrainState, PRNGKeyArray | None],
+    tuple[Agent[State, Action, ScanX], TrainState],
+]
+
+
+# TODO Maybe this could just be a function `train` that receives train_step
+class Trainer[TrainState, State, Action, ScanX](Module, strict=True):
+    train_step: TrainStepFn[TrainState, State, Action, ScanX]
+
+    def __call__(
+        self,
+        agent: Agent[State, Action, ScanX],
+        train_state: TrainState,
+        steps: int,
+        rng_key: PRNGKeyArray | None,
+    ) -> tuple[Agent[State, Action, ScanX], TrainState]:
+        if rng_key is None:
+            step_keys = [None] * steps
+        else:
+            step_keys = jr.split(rng_key, steps)
+
+        # TODO Implement something like `lax.scan`'s YS to extract a record
+        # TODO Would it be crazy to `lax.scan` over batches?
+
+        for step_key in step_keys:
+            agent, train_state = self.train_step(agent, train_state, step_key)
+
+        return agent, train_state

--- a/scripts/experimental/lib/v1/game.py
+++ b/scripts/experimental/lib/v1/game.py
@@ -1,0 +1,71 @@
+"""Elements of Plantation amenable to JAX autograd and jit."""
+
+from enum import IntEnum
+
+import jax.lax as lax
+import jax.numpy as jnp
+from jaxtyping import Array, Bool, UInt
+
+
+BOARD_HEIGHT = 11
+BOARD_WIDTH = 11
+
+BOARD_SHAPE = (BOARD_HEIGHT, BOARD_WIDTH)
+
+type BoardBool = Bool[Array, "height width"]
+type BoardUInt = UInt[Array, "height width"]
+
+NUM_ACTIONS = 2
+
+type ActionBool = Bool[Array, "height width actions"]
+
+
+class Act(IntEnum):
+    """Index of an action type in the `actions` dimension of `ActionBool`"""
+    FR = 0
+    """Fertilise"""
+    PL = 1
+    """Plant"""
+    SC = 2
+    """Scout"""
+    BM = 3
+    """Bomb"""
+    SP = 4
+    """Spray"""
+    # CO = 5  # FIXME What about this, son?
+
+
+def allowed_actions(player_board: BoardUInt) -> ActionBool:
+    """Actions allowed according to the state of ONE PLAYER's pieces.
+
+    Actions are considered allowed even if their direct effect on the board is
+    ultimately blocked due to the opponent's position.
+    """
+    # NOTE Maintain the correct order in the stack, as in enum `Act`.
+    return jnp.stack(
+        (
+            allowed_fertilise(player_board),
+            allowed_plant(player_board),
+        ),
+        axis=-1,
+    )
+
+
+def allowed_fertilise(player_board: BoardUInt) -> BoardBool:
+    return player_board.astype('bool')
+
+
+def allowed_plant(player_board: BoardUInt) -> BoardBool:
+    occupied = player_board.astype('bool')
+
+    return lax.full_like(
+        occupied, False
+    ).at[:, 1:].set(
+        occupied[:, :-1]
+    ).at[:, :-1].set(
+        occupied[:, 1:]
+    ).at[:-1, :].set(
+        occupied[1:, :]
+    ).at[1:, :].set(
+        occupied[:-1, :]
+    ) & ~occupied


### PR DESCRIPTION
Should be safe to merge, doesn't mess with any existing code.

I want to train a neural net to play Plantation by building a simulator amenable to autograd. Pretty sure it's possible, though it might be a substantial amount of work.

This is a first step that doesn't simulate any dynamics, but trains an MLP to produce only legal moves, with no strong preference, considering only `fertilise` and `plant`. Obviously an easy task (even a one unit hidden layer can get quite good) but useful to sketch out framework for more interesting problems.

The plan is roughly:

1. Integrate all the moves
2. Switch to convolutional architecture
3. Learn to grow
4. Learn to kill
5. Learn to play competitively through self-play